### PR TITLE
Implement party question RN prototype

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './src/screens/HomeScreen';
+import CreateGameScreen from './src/screens/CreateGameScreen';
+import JoinGameScreen from './src/screens/JoinGameScreen';
+import LobbyScreen from './src/screens/LobbyScreen';
+import QuestionScreen from './src/screens/QuestionScreen';
+import GameStartScreen from './src/screens/GameStartScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Home">
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="CreateGame" component={CreateGameScreen} />
+        <Stack.Screen name="JoinGame" component={JoinGameScreen} />
+        <Stack.Screen name="Lobby" component={LobbyScreen} />
+        <Stack.Screen name="Question" component={QuestionScreen} />
+        <Stack.Screen name="GameStart" component={GameStartScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# codexTest
+# Party Questions App
+
+This is a simple React Native (Expo) prototype that allows a host to create a room and distribute secret questions to players. One player receives an "odd" question while everyone else gets the same main question. The app is only responsible for distributing questions and starting the offline discussion.
+
+## Setup
+
+1. Install [Expo CLI](https://docs.expo.dev/get-started/installation/) globally.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Configure Firebase.
+   - Copy your Firebase project credentials into `src/firebase.js`.
+
+4. Run the development server:
+
+```bash
+npm start
+```
+
+Use the Expo Go app or an emulator to test.
+
+## Project Structure
+
+- `App.js` – navigation setup
+- `src/screens/*` – individual screens
+- `src/firebase.js` – Firebase initialization (Firestore)
+- `src/questions.js` – sample question pairs
+
+This project focuses on the basic game flow and room/question management. UI styling is minimal for clarity.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "party-questions-app",
+  "version": "1.0.0",
+  "main": "App.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "firebase": "^9.23.0"
+  }
+}

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,15 @@
+// Basic Firebase initialization
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'YOUR_AUTH_DOMAIN',
+  projectId: 'YOUR_PROJECT_ID',
+  storageBucket: 'YOUR_STORAGE_BUCKET',
+  messagingSenderId: 'YOUR_MESSAGING_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);

--- a/src/questions.js
+++ b/src/questions.js
@@ -1,0 +1,9 @@
+export const MAIN_QUESTIONS = [
+  'What is your favourite fruit?',
+  'What is your favourite color?',
+];
+
+export const ODD_QUESTIONS = [
+  'What is your favourite vegetable?',
+  'What is your favourite animal?',
+];

--- a/src/screens/CreateGameScreen.js
+++ b/src/screens/CreateGameScreen.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { View, Button, TextInput, StyleSheet } from 'react-native';
+import { collection, addDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function CreateGameScreen({ navigation }) {
+  const [name, setName] = useState('');
+  const createRoom = async () => {
+    const docRef = await addDoc(collection(db, 'rooms'), {
+      hostName: name || 'Host',
+      players: [],
+      phase: 'lobby',
+    });
+    navigation.navigate('Lobby', { roomId: docRef.id, host: true, name: name || 'Host' });
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="Your name" value={name} onChangeText={setName} style={styles.input} />
+      <Button title="Create" onPress={createRoom} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  input: { borderWidth: 1, padding: 8, margin: 10, width: '80%' },
+});

--- a/src/screens/GameStartScreen.js
+++ b/src/screens/GameStartScreen.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function GameStartScreen() {
+  return (
+    <View style={styles.container}>
+      <Text>Discuss among yourselves to find the odd one out!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+});

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Button, StyleSheet } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Button title="Create Game" onPress={() => navigation.navigate('CreateGame')} />
+      <Button title="Join Game" onPress={() => navigation.navigate('JoinGame')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/screens/JoinGameScreen.js
+++ b/src/screens/JoinGameScreen.js
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { View, Button, TextInput, StyleSheet, Alert } from 'react-native';
+import { doc, getDoc, updateDoc, arrayUnion } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function JoinGameScreen({ navigation }) {
+  const [name, setName] = useState('');
+  const [code, setCode] = useState('');
+
+  const joinRoom = async () => {
+    const roomRef = doc(db, 'rooms', code.trim());
+    const roomSnap = await getDoc(roomRef);
+    if (!roomSnap.exists()) {
+      Alert.alert('Invalid code');
+      return;
+    }
+    await updateDoc(roomRef, { players: arrayUnion({ id: Date.now().toString(), name: name || 'Player' }) });
+    navigation.navigate('Lobby', { roomId: code.trim(), host: false, name: name || 'Player' });
+  };
+
+  return (
+    <View style={styles.container}>
+      <TextInput placeholder="Your name" value={name} onChangeText={setName} style={styles.input} />
+      <TextInput placeholder="Room code" value={code} onChangeText={setCode} style={styles.input} />
+      <Button title="Join" onPress={joinRoom} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  input: { borderWidth: 1, padding: 8, margin: 10, width: '80%' },
+});

--- a/src/screens/LobbyScreen.js
+++ b/src/screens/LobbyScreen.js
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
+import { doc, onSnapshot, updateDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import { MAIN_QUESTIONS, ODD_QUESTIONS } from '../questions';
+
+export default function LobbyScreen({ navigation, route }) {
+  const { roomId, host, name } = route.params;
+  const [players, setPlayers] = useState([]);
+  const [roomCode] = useState(roomId);
+
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, 'rooms', roomId), snap => {
+      const data = snap.data();
+      if (data.phase === 'question') {
+        navigation.replace('Question', { roomId, playerName: name });
+      }
+      setPlayers(data.players || []);
+    });
+    return unsub;
+  }, []);
+
+  const startGame = async () => {
+    const questionIndex = Math.floor(Math.random() * MAIN_QUESTIONS.length);
+    const oddPlayerIndex = Math.floor(Math.random() * (players.length + 1));
+    const assignments = {};
+    players.concat([{ id: 'host', name }]).forEach((p, idx) => {
+      assignments[p.id] = idx === oddPlayerIndex ? ODD_QUESTIONS[questionIndex] : MAIN_QUESTIONS[questionIndex];
+    });
+    await updateDoc(doc(db, 'rooms', roomId), { phase: 'question', assigned: assignments });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text>Room Code: {roomCode}</Text>
+      <FlatList data={[{ id: 'host', name }, ...players]} keyExtractor={item => item.id} renderItem={({ item }) => <Text>{item.name}</Text>} />
+      {host && <Button title="Start Game" onPress={startGame} />}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', padding: 20 },
+});

--- a/src/screens/QuestionScreen.js
+++ b/src/screens/QuestionScreen.js
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Button } from 'react-native';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function QuestionScreen({ navigation, route }) {
+  const { roomId, playerName } = route.params;
+  const [question, setQuestion] = useState('');
+
+  useEffect(() => {
+    const unsub = onSnapshot(doc(db, 'rooms', roomId), snap => {
+      const data = snap.data();
+      if (data.phase === 'question' && data.assigned) {
+        const key = data.players.find(p => p.name === playerName)?.id || 'host';
+        setQuestion(data.assigned[key]);
+      }
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <Text>Your question:</Text>
+      <Text style={styles.q}>{question}</Text>
+      <Button title="Begin Discussion" onPress={() => navigation.replace('GameStart')} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 20 },
+  q: { fontSize: 18, marginVertical: 20 },
+});


### PR DESCRIPTION
## Summary
- scaffold an Expo project with navigation
- add Firebase helpers and example question data
- implement basic screens for creating, joining and starting a game
- document setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684713b767a48333b76c94e15bc18e60